### PR TITLE
fix android binary name

### DIFF
--- a/pvr.pctv/addon.xml
+++ b/pvr.pctv/addon.xml
@@ -14,7 +14,7 @@
     library_osx="pvr.pctv.dylib"
     library_freebsd="pvr.pctv.so"
     library_windx="pvr.pctv.dll"
-    library_android="libpvr.pctv.dll" />
+    library_android="libpvr.pctv.so" />
   <extension point="xbmc.addon.metadata">
     <summary lang="en">PVR Client to connect PCTV Systems Broadway to Kodi</summary>
     <description lang="en">PCTV Systems frontend. Supporting streaming of Live TV &amp; Recordings, EPG View, Timers.</description>


### PR DESCRIPTION
.so, not .dll