### PR TITLE
[debian] adds missing dependency libjsoncpp-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-pctv
 Priority: extra
 Maintainer: hg1 <gerlach.holger@gmail.com>
 Build-Depends: debhelper (>= 9.0.0), cmake, kodi-pvr-dev,
-               libkodiplatform-dev, kodi-addon-dev
+               libkodiplatform-dev, kodi-addon-dev, libjsoncpp-dev
 Standards-Version: 3.9.4
 Section: libs
 


### PR DESCRIPTION
@wsnipex ping
