### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.pctv/addon.xml
+++ b/pvr.pctv/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.pctv"
-  version="0.1.9"
+  version="0.2.0"
   name="PCTV Systems Client"
   provider-name="PCTV Systems">
   <requires>

--- a/pvr.pctv/addon.xml
+++ b/pvr.pctv/addon.xml
@@ -6,7 +6,7 @@
   provider-name="PCTV Systems">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.pctv/changelog.txt
+++ b/pvr.pctv/changelog.txt
@@ -1,3 +1,6 @@
+0.2.0
+- Updated to API v1.9.7
+
 0.1.9
 - Updated Language files from Transifex
 

--- a/src/PctvData.cpp
+++ b/src/PctvData.cpp
@@ -526,6 +526,10 @@ void Pctv::TransferTimer(ADDON_HANDLE handle)
     PctvTimer &timer = m_timer.at(i);
     PVR_TIMER tag;
     memset(&tag, 0, sizeof(PVR_TIMER));
+
+    /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+    tag.iTimerType = PVR_TIMER_TYPE_NONE;
+
     tag.iClientIndex = timer.iId;
     tag.iClientChannelUid = timer.iChannelId;
     strncpy(tag.strTitle, timer.strTitle.c_str(), sizeof(tag.strTitle));
@@ -535,7 +539,6 @@ void Pctv::TransferTimer(ADDON_HANDLE handle)
     tag.strDirectory[0] = '\0';
     tag.iPriority = 0;
     tag.iLifetime = 0;
-    tag.bIsRepeating = false;
     tag.iEpgUid = 0;
 
     PVR->TransferTimerEntry(handle, &tag);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -466,6 +466,12 @@ PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted)
   return PctvData->GetRecordings(handle);
 }
 
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+{
+  /* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 int GetTimersAmount(void)
 {
   if (!PctvData || !PctvData->IsConnected())
@@ -479,6 +485,7 @@ PVR_ERROR GetTimers(ADDON_HANDLE handle)
   if (!PctvData || !PctvData->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
 
+  /* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
   return PctvData->GetTimers(handle);
 }
 
@@ -533,7 +540,7 @@ PVR_ERROR UpdateTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED
 PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)  { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteScheduled)  { return PVR_ERROR_NOT_IMPLEMENTED; }
 int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 bool OpenRecordedStream(const PVR_RECORDING &recording) { return false; }
 void CloseRecordedStream(void) {}


### PR DESCRIPTION
For, J**** PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J**** and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.