### PR TITLE
Update to PVR addon API v4.0.0

### DIFF
--- a/pvr.pctv/addon.xml.in
+++ b/pvr.pctv/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.pctv"
-  version="0.2.4"
+  version="0.2.5"
   name="PCTV Systems Client"
   provider-name="PCTV Systems">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="3.0.0"/>
+    <import addon="xbmc.pvr" version="4.0.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.pctv/changelog.txt
+++ b/pvr.pctv/changelog.txt
@@ -1,3 +1,6 @@
+0.2.5
+- Updated to PVR API v4.0.0
+
 0.2.4
 - Updated to PVR API v3.0.0 (API 1.9.7 Compatibility Mode)
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -540,7 +540,7 @@ PVR_ERROR UpdateTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED
 PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteScheduled)  { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)  { return PVR_ERROR_NOT_IMPLEMENTED; }
 int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 bool OpenRecordedStream(const PVR_RECORDING &recording) { return false; }
 void CloseRecordedStream(void) {}


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.0.0, including a PVR addon micro version bump.

Details can be found here: https://github.com/xbmc/xbmc/pull/8005