### PR TITLE
libXBMC_codec.h removed and changed to libXBMC_pvr.h

### DIFF
--- a/pvr.pctv/addon.xml.in
+++ b/pvr.pctv/addon.xml.in
@@ -6,7 +6,7 @@
   provider-name="PCTV Systems">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="5.2.1"/>
+    <import addon="xbmc.pvr" version="5.2.2"/>
   </requires>
   <extension
     point="xbmc.pvrclient"


### PR DESCRIPTION
Related to Kodi Pull Request xbmc/xbmc#12028 where libXBMC_codec.h becomes removed.