### PR TITLE
[Testing Required] update to PVR addon API 5.7.0

### DIFF
--- a/depends/common/jsoncpp/jsoncpp.txt
+++ b/depends/common/jsoncpp/jsoncpp.txt
@@ -1,1 +1,1 @@
-jsoncpp http://mirrors.kodi.tv/build-deps/sources/jsoncpp-src-0.5.0.tar.gz
+jsoncpp https://github.com/open-source-parsers/jsoncpp/archive/0.10.6.tar.gz

--- a/pvr.pctv/addon.xml.in
+++ b/pvr.pctv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.pctv"
-  version="2.1.1"
+  version="2.2.0"
   name="PCTV Systems Client"
   provider-name="PCTV Systems">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.pctv/changelog.txt
+++ b/pvr.pctv/changelog.txt
@@ -1,3 +1,8 @@
+2.2.0
+- Updated to PVR addon API v5.7.0
+- bumped jsoncpp to 0.10.6
+- changed jsoncpp deprecated method to new method getFormattedErrorMessages
+
 2.1.0
 - Updated to PVR addon API v5.3.0
 

--- a/src/PctvData.h
+++ b/src/PctvData.h
@@ -153,7 +153,8 @@ public:
   /* Channels */
   unsigned int GetChannelsAmount(void);
   bool GetChannel(const PVR_CHANNEL &channel, PctvChannel &myChannel);
-  PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);  
+  PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
+  PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount);
 
   /* Groups */
   unsigned int GetChannelGroupsAmount(void);  
@@ -164,7 +165,8 @@ public:
   PVR_ERROR GetRecordings(ADDON_HANDLE handle);
   bool GetRecordingFromLocation(CStdString strRecordingFolder);
   unsigned int GetRecordingsAmount(void);
-  
+  PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount);
+
   /* Timer */
   unsigned int GetTimersAmount(void);
   PVR_ERROR GetTimers(ADDON_HANDLE handle);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -404,13 +404,6 @@ void CloseLiveStream(void)
   }  
 }
 
-bool SwitchChannel(const PVR_CHANNEL &channel)
-{
-  CloseLiveStream();
-
-  return OpenLiveStream(channel);
-}
-
 PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time_t iStart, time_t iEnd)
 {
   if (!PctvData || !PctvData->IsConnected())
@@ -494,9 +487,21 @@ PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &g
   return PctvData->GetChannelGroupMembers(handle, group);
 }
 
+PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount) {
+  if (!PctvData || !PctvData->IsConnected())
+    return PVR_ERROR_SERVER_ERROR;
+
+  return PctvData->GetChannelStreamProperties(channel, properties, iPropertiesCount);
+}
+
+PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount) {
+  if (!PctvData || !PctvData->IsConnected())
+    return PVR_ERROR_SERVER_ERROR;
+
+  return PctvData->GetRecordingStreamProperties(recording, properties, iPropertiesCount);
+}
 
 /** UNUSED API FUNCTIONS */
-const char * GetLiveStreamURL(const PVR_CHANNEL &channel)  { return ""; }
 PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus) { return PVR_ERROR_NO_ERROR; }
 PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES* pProperties) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxAbort(void) { return; }
@@ -525,7 +530,6 @@ long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
 PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*) { return PVR_ERROR_NOT_IMPLEMENTED; };
-unsigned int GetChannelSwitchDelay(void) { return 0; }
 void PauseStream(bool bPaused) {}
 bool CanPauseStream(void) { return false; }
 bool CanSeekStream(void) { return false; }
@@ -544,4 +548,8 @@ PVR_ERROR OpenDialogChannelAdd(const PVR_CHANNEL &channel) { return PVR_ERROR_NO
 PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR IsEPGTagPlayable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR IsEPGTagRecordable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -41,7 +41,7 @@ int cRest::Get(const std::string& command, const std::string& arguments, Json::V
 			{
 				XBMC->Log(LOG_DEBUG, "Failed to parse %s: \n%s\n",
 					response.c_str(),
-					reader.getFormatedErrorMessages().c_str());
+					reader.getFormattedErrorMessages().c_str());
 				return E_FAILED;
 			}
 		}
@@ -73,7 +73,7 @@ int cRest::Post(const std::string& command, const std::string& arguments, Json::
 			{
 				XBMC->Log(LOG_DEBUG, "Failed to parse %s: \n%s\n",
 					response.c_str(),
-					reader.getFormatedErrorMessages().c_str());
+					reader.getFormattedErrorMessages().c_str());
 				return E_FAILED;
 			}
 		}


### PR DESCRIPTION
This brings the addon upto API 5.7.0 compatibility
Removed deprecated methods and stubbed out new ones
Bumped jsoncpp to 0.10.6 and changed to non deprecated getFormattedErrorMessages(). No functional change for this, as the deprecation was done purely because of the type in the function name.

Please note, ive not been able to test functionality at all. If anyone can let me know if the changes work, or need further tweaking. This was a quick attempt to get up and running, so feedback is very appreciated.