### PR TITLE
Fix deprecated function warnings

### DIFF
--- a/pvr.pctv/changelog.txt
+++ b/pvr.pctv/changelog.txt
@@ -1,3 +1,6 @@
+2.3.1
+- Replace deprecated jsoncpp methods
+
 2.3.0
 - Updated to PVR addon API v5.8.0
 

--- a/src/PctvData.cpp
+++ b/src/PctvData.cpp
@@ -102,7 +102,7 @@ bool Pctv::Open()
   std::string strAuth = "";
   if (m_bUsePIN)
   {
-	  std::string pinMD5 = XBMCPVR::XBMC_MD5::GetMD5(g_strPin);
+	  std::string pinMD5 = XBMC_MD5::GetMD5(g_strPin);
 	  StringUtils::ToLower(pinMD5);
 
 	  strURL= StringUtils::Format("User:%s@", pinMD5.c_str());

--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -30,34 +30,33 @@ static void MD5Final(unsigned char digest[16], struct MD5Context *context);
 static void MD5Transform(uint32_t buf[4], uint32_t const in[16]);
 
 
-XBMCPVR::XBMC_MD5::XBMC_MD5(void)
+XBMC_MD5::XBMC_MD5(void)
 {
   MD5Init(&m_ctx);
 }
 
-XBMCPVR::XBMC_MD5::~XBMC_MD5(void)
-{}
+XBMC_MD5::~XBMC_MD5(void) = default;
 
-void XBMCPVR::XBMC_MD5::append(const void *inBuf, size_t inLen)
+void XBMC_MD5::append(const void *inBuf, size_t inLen)
 {
   MD5Update(&m_ctx, (md5byte*)inBuf, inLen);
 }
 
-void XBMCPVR::XBMC_MD5::append(const std::string& str)
+void XBMC_MD5::append(const std::string& str)
 {
   append((unsigned char*) str.c_str(), (unsigned int) str.length());
 }
 
-void XBMCPVR::XBMC_MD5::getDigest(unsigned char digest[16])
+void XBMC_MD5::getDigest(unsigned char digest[16])
 {
   MD5Final(digest, &m_ctx);
 }
 
-void XBMCPVR::XBMC_MD5::getDigest(std::string& digest)
+std::string XBMC_MD5::getDigest()
 {
   unsigned char szBuf[16] = {'\0'};
   getDigest(szBuf);
-  digest = StringUtils::Format("%02X%02X%02X%02X%02X%02X%02X%02X"\
+  return StringUtils::Format("%02X%02X%02X%02X%02X%02X%02X%02X"\
                              "%02X%02X%02X%02X%02X%02X%02X%02X",
                              szBuf[0], szBuf[1], szBuf[2],
                              szBuf[3], szBuf[4], szBuf[5], szBuf[6], szBuf[7], szBuf[8],
@@ -65,15 +64,13 @@ void XBMCPVR::XBMC_MD5::getDigest(std::string& digest)
                              szBuf[15]);
 }
 
-std::string XBMCPVR::XBMC_MD5::GetMD5(const std::string &text)
+std::string XBMC_MD5::GetMD5(const std::string &text)
 {
   if (text.empty())
     return "";
   XBMC_MD5 state;
-  std::string digest;
   state.append(text);
-  state.getDigest(digest);
-  return digest;
+  return state.getDigest();
 }
 
 /*
@@ -98,13 +95,8 @@ std::string XBMCPVR::XBMC_MD5::GetMD5(const std::string &text)
  * Still in the public domain.
  */
 
-#include "md5.h"
-
 #include <sys/types.h>		/* for stupid systems */
 #include <string.h>		/* for memcpy() */
-#if defined(HAVE_CONFIG_H) && !defined(TARGET_WINDOWS)
-#include "../config.h"
-#endif
 
 #ifdef WORDS_BIGENDIAN
 void
@@ -236,7 +228,7 @@ MD5Final(md5byte digest[16], struct MD5Context *ctx)
 static void
 MD5Transform(uint32_t buf[4], uint32_t const in[16])
 {
-	register uint32_t a, b, c, d;
+	uint32_t a, b, c, d;
 
 	a = buf[0];
 	b = buf[1];

--- a/src/md5.h
+++ b/src/md5.h
@@ -1,6 +1,8 @@
+#pragma once
+
 /*
- *      Copyright (C) 2009-2013 Team XBMC
- *      http://xbmc.org
+ *      Copyright (C) 2009-2015 Team Kodi
+ *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -13,17 +15,13 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
+ *  along with Kodi; see the file COPYING.  If not, see
  *  <http://www.gnu.org/licenses/>.
  *
  */
 
-#ifndef _MD5_H_
-#define _MD5_H_
-
 #include <string>
 #include <stdint.h>
-
 
 struct MD5Context {
 	uint32_t buf[4];
@@ -31,26 +29,21 @@ struct MD5Context {
 	uint32_t in[16];
 };
 
-namespace XBMCPVR
+class XBMC_MD5
 {
-  class XBMC_MD5
-  {
-  public:
-    XBMC_MD5(void);
-    ~XBMC_MD5(void);
-    void append(const void *inBuf, size_t inLen);
-    void append(const std::string& str);
-    void getDigest(unsigned char digest[16]);
-    void getDigest(std::string& digest);
+public:
+  XBMC_MD5(void);
+  ~XBMC_MD5(void);
+  void append(const void *inBuf, size_t inLen);
+  void append(const std::string& str);
+  void getDigest(unsigned char digest[16]);
+  std::string getDigest();
 
-    /*! \brief Get the MD5 digest of the given text
-     \param text text to compute the MD5 for
-     \return MD5 digest
-     */
-    static std::string GetMD5(const std::string& text);
+  /*! \brief Get the MD5 digest of the given text
+   \param text text to compute the MD5 for
+   \return MD5 digest
+   */
+  static std::string GetMD5(const std::string &text);
 private:
-    MD5Context m_ctx;
-  };
-}
-
-#endif
+  MD5Context m_ctx;
+};

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -17,6 +17,7 @@
 *
 */
 #include "rest.h"
+#include <memory>
 #include <vector>
 #include <stdlib.h>
 #include <string.h>
@@ -33,15 +34,15 @@ int cRest::Get(const std::string& command, const std::string& arguments, Json::V
 	{
 		if (response.length() != 0)
 		{
-			Json::Reader reader;
+			std::string jsonReaderError;
+			Json::CharReaderBuilder jsonReaderBuilder;
+			std::unique_ptr<Json::CharReader> const reader(jsonReaderBuilder.newCharReader());
 
-			bool parsingSuccessful = reader.parse(response, json_response);
-
-			if (!parsingSuccessful)
+			if (!reader->parse(response.c_str(), response.c_str() + response.size(), &json_response, &jsonReaderError))
 			{
 				XBMC->Log(LOG_DEBUG, "Failed to parse %s: \n%s\n",
 					response.c_str(),
-					reader.getFormattedErrorMessages().c_str());
+					jsonReaderError.c_str());
 				return E_FAILED;
 			}
 		}
@@ -65,15 +66,15 @@ int cRest::Post(const std::string& command, const std::string& arguments, Json::
 	{
 		if (response.length() != 0)
 		{
-			Json::Reader reader;
+			std::string jsonReaderError;
+			Json::CharReaderBuilder jsonReaderBuilder;
+			std::unique_ptr<Json::CharReader> const reader(jsonReaderBuilder.newCharReader());
 
-			bool parsingSuccessful = reader.parse(response, json_response);
-
-			if (!parsingSuccessful)
+			if (!reader->parse(response.c_str(), response.c_str() + response.size(), &json_response, &jsonReaderError))
 			{
 				XBMC->Log(LOG_DEBUG, "Failed to parse %s: \n%s\n",
 					response.c_str(),
-					reader.getFormattedErrorMessages().c_str());
+					jsonReaderError.c_str());
 				return E_FAILED;
 			}
 		}


### PR DESCRIPTION
Fixes deprecation warnings when building.

First fix just updates the md5 implementation to the latest kodi one that it was based on. This removes the register deprecation warning.

Second changes the Json::Reader to use the new Json::CharReader. As the new charreader outputs the error, the getformattederror function is removed, and the errorstring is used.

Changes arent runtime tested, but should all work.