### PR TITLE
src/utils.h: add cstdarg include

### DIFF
--- a/pvr.pctv/addon.xml.in
+++ b/pvr.pctv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.pctv"
-  version="5.0.0"
+  version="5.0.1"
   name="PCTV Systems Client"
   provider-name="PCTV Systems">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.pctv/changelog.txt
+++ b/pvr.pctv/changelog.txt
@@ -1,3 +1,6 @@
+5.0.1
+- src/utils.h: add cstdarg include
+
 5.0.0
 - Updated PVR API 7.0.0
 - Rework addon to support new API interface

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,6 +7,7 @@
  */
 
 #include <string>
+#include <cstdarg>
 
 #pragma once
 


### PR DESCRIPTION
Fixes build error with gcc 8.3.0:

src/utils.h:17:47: error: ‘va_list’ has not been declared
   static std::string FormatV(const char* fmt, va_list args);