### PR TITLE
PVR API 7.1.0 - changelog and version v6.1.0

### DIFF
--- a/pvr.pctv/addon.xml.in
+++ b/pvr.pctv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.pctv"
-  version="6.0.0"
+  version="6.1.0"
   name="PCTV Systems Client"
   provider-name="PCTV Systems">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.pctv/changelog.txt
+++ b/pvr.pctv/changelog.txt
@@ -1,3 +1,6 @@
+v6.1.0
+- Update PVR API 7.1.0
+
 6.0.0
 - Update PVR API 7.0.2
 - Update to use dev-kit API kodi::tools::StringUtils about string format


### PR DESCRIPTION
v6.1.0
- Update PVR API 7.1.0

Not to be merged until xbmc/xbmc#19035 is merged.