### PR TITLE
[Nexus] Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.pctv/addon.xml.in
+++ b/pvr.pctv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.pctv"
-  version="20.0.0"
+  version="20.1.0"
   name="PCTV Systems Client"
   provider-name="PCTV Systems">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.pctv/changelog.txt
+++ b/pvr.pctv/changelog.txt
@@ -1,3 +1,6 @@
+v20.1.0
+￼- Kodi PVR API to 8.0.0
+
 v20.0.0
 - Translations updates from Weblate
   - Korean (ko_kr), Russian (ru_ru), Polish (pl_pl) and Danish (da_dk)

--- a/src/PctvData.cpp
+++ b/src/PctvData.cpp
@@ -935,6 +935,7 @@ PVR_ERROR Pctv::GetCapabilities(kodi::addon::PVRCapabilities& capabilities)
   capabilities.SetSupportsRadio(false);
   capabilities.SetSupportsChannelGroups(true);
   capabilities.SetSupportsRecordings(true);
+  capabilities.SetSupportsRecordingsDelete(false);
   capabilities.SetSupportsRecordingsUndelete(false);
   capabilities.SetSupportsTimers(true);
   capabilities.SetSupportsChannelScan(false);


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Add supports recordings delete capability
  - Add support for PVR Providers and parental rating code for EPG
  - Enforce EDL limits

**Changes not direct relate to this addon.**

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395